### PR TITLE
Fixed Github Icon Issue and Added Animation to SVG's

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -27,7 +27,10 @@ body {
     position: relative;
 }
 
-
+.wrapper .container a{
+    color: inherit;
+    text-decoration: none;
+}
 
 .wrapper .container a .GitHubIcon{
     position: absolute;
@@ -35,6 +38,17 @@ body {
     right: 3rem;
     font-size: 4rem;
     cursor: pointer;
+    transition: all 0.1s linear;
+}
+
+.wrapper .container a .GitHubIcon:hover{
+    font-size: 4.4rem;
+    right: 2.8rem;
+}
+
+.wrapper .container a .GitHubIcon:active{
+    font-size: 3.8rem;
+    right: 3.1rem;
 }
 
 .wrapper .container .greeting{
@@ -165,6 +179,10 @@ body {
 
 .wrapper .container .accordion_wrapper .accordion_container .active{
     display: flex;
+}
+
+.wrapper .container .footer-social-icons a{
+    transition: all 0.1s linear;
 }
 
 


### PR DESCRIPTION
ISSUE : - Adding Animations to SVGs #299

The Github SVG had the ``a`` tag, so was working differently

![Gthub](https://user-images.githubusercontent.com/89806031/194460334-0d054426-1e5a-488b-bfec-f67b32c9704e.png)

On Click :-
![Gt](https://user-images.githubusercontent.com/89806031/194460348-273fe851-87d0-4438-b8b8-30b875e56c5e.png)

Fixed the SVG and added a smooth animation :-
![Githb](https://user-images.githubusercontent.com/89806031/194460588-8dc072dd-b537-4551-b8dd-168780dee49c.png)

Smoothened the animation of footer SVG's as well :- 
![Footer](https://user-images.githubusercontent.com/89806031/194460688-1cf6135f-9819-44eb-951a-7425e8e7d02c.png)
